### PR TITLE
Subset of Commands for Ordered Sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Delve build artifacts
+**__debug_bin**

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ FoundationDB provides strictly serializable transactions atop an ordered key-val
 |`redis_v0/<user_id>/obj/<obj_id>`|Storage of data objects|
 |`redis_v0/<user_id>/list/<list_id>`|Metadata protobuf for information on each list|
 |`redis_v0/<user_id>/list/<list_id>/<item_id>`|Metadata protobuf for information on each item in a list|
+|`redis_v0/<user_id>/zset/<set_id>`|Stores an ordered list of item scores for ordered sets|

--- a/internal/server/redis/auth.go
+++ b/internal/server/redis/auth.go
@@ -117,13 +117,19 @@ func (s *session) setSessionUser(user *types.User) error {
 		return fmt.Errorf("failed to initialize user list directory: %w", err)
 	}
 
+	zsetDir, err := userDir.CreateOrOpen(s.fdb, []string{"zset"}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to initialize user zset directory: %w", err)
+	}
+
 	s.userMu.Lock()
-	s.user = &sessionUser{
+	s.user = &userSession{
 		objDir:        objDir,
 		metaDir:       metaDir,
 		uidDir:        uidDir,
 		reverseUIDDir: reverseUIDDir,
 		listDir:       listDir,
+		zsetDir:       zsetDir,
 		user:          user,
 	}
 	s.userMu.Unlock()

--- a/internal/server/redis/list.go
+++ b/internal/server/redis/list.go
@@ -97,7 +97,7 @@ func (s *session) handlePush(ctx context.Context, args []resp.Value, left bool) 
 	}
 
 	_, err = s.fdb.Transact(func(tx fdb.Transaction) (any, error) {
-		listMetaKey, objMeta, err := s.getObjectMeta(ctx, tx, key)
+		listMetaKey, objMeta, err := s.getMeta(ctx, tx, key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get list meta: %w", err)
 		}

--- a/internal/server/redis/object.go
+++ b/internal/server/redis/object.go
@@ -23,6 +23,7 @@ type objectKind int64
 const (
 	objectKindBasic objectKind = 1 << iota
 	objectKindSet
+	objectKindSortedSet
 	objectKindList
 	objectKindListItem
 )
@@ -44,6 +45,9 @@ func getNumChunks(meta *types.ObjectMeta, kind gt.Option[objectKind]) (uint32, e
 	case *types.ObjectMeta_Set:
 		objKind = objectKindSet
 		numChunks = typ.Set.NumChunks
+	case *types.ObjectMeta_SortedSet:
+		objKind = objectKindSet
+		numChunks = typ.SortedSet.Set.NumChunks
 	case *types.ObjectMeta_ListItem:
 		objKind = objectKindListItem
 		numChunks = typ.ListItem.NumChunks
@@ -137,6 +141,10 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 			meta.Type = &types.ObjectMeta_Basic{Basic: &types.BasicObjectMeta{}}
 		case objectKindSet:
 			meta.Type = &types.ObjectMeta_Set{Set: &types.SetMeta{}}
+		case objectKindSortedSet:
+			meta.Type = &types.ObjectMeta_SortedSet{SortedSet: &types.SortedSetMeta{
+				Set: &types.SetMeta{},
+			}}
 		case objectKindListItem:
 			meta.Type = &types.ObjectMeta_ListItem{ListItem: &types.ListItemMeta{}}
 		}
@@ -157,6 +165,8 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 		typ.Basic.NumChunks = numChunks
 	case *types.ObjectMeta_Set:
 		typ.Set.NumChunks = numChunks
+	case *types.ObjectMeta_SortedSet:
+		typ.SortedSet.Set.NumChunks = numChunks
 	case *types.ObjectMeta_ListItem:
 		typ.ListItem.NumChunks = numChunks
 	}

--- a/internal/server/redis/object.go
+++ b/internal/server/redis/object.go
@@ -362,8 +362,10 @@ func (s *session) handleDelete(ctx context.Context, args []resp.Value) (string, 
 				return false, fmt.Errorf("failed to get sorted set score directory: %w", err)
 			}
 
-			begin, end := scoreDir.FDBRangeKeys()
-			tx.ClearRange(fdb.KeyRange{Begin: begin, End: end})
+			_, err = scoreDir.Remove(tx, []string{})
+			if err != nil {
+				return false, fmt.Errorf("failed to remove score directory: %w", err)
+			}
 		}
 
 		return true, nil

--- a/internal/server/redis/object.go
+++ b/internal/server/redis/object.go
@@ -23,6 +23,7 @@ type objectKind int64
 const (
 	objectKindBasic objectKind = 1 << iota
 	objectKindSet
+	objectKindSortedSet
 	objectKindList
 	objectKindListItem
 )
@@ -44,6 +45,9 @@ func getNumChunks(meta *types.ObjectMeta, kind gt.Option[objectKind]) (uint32, e
 	case *types.ObjectMeta_Set:
 		objKind = objectKindSet
 		numChunks = typ.Set.NumChunks
+	case *types.ObjectMeta_SortedSet:
+		objKind = objectKindSet
+		numChunks = typ.SortedSet.NumChunks
 	case *types.ObjectMeta_ListItem:
 		objKind = objectKindListItem
 		numChunks = typ.ListItem.NumChunks
@@ -137,6 +141,8 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 			meta.Type = &types.ObjectMeta_Basic{Basic: &types.BasicObjectMeta{}}
 		case objectKindSet:
 			meta.Type = &types.ObjectMeta_Set{Set: &types.SetMeta{}}
+		case objectKindSortedSet:
+			meta.Type = &types.ObjectMeta_SortedSet{SortedSet: &types.SortedSetMeta{}}
 		case objectKindListItem:
 			meta.Type = &types.ObjectMeta_ListItem{ListItem: &types.ListItemMeta{}}
 		}
@@ -157,6 +163,8 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 		typ.Basic.NumChunks = numChunks
 	case *types.ObjectMeta_Set:
 		typ.Set.NumChunks = numChunks
+	case *types.ObjectMeta_SortedSet:
+		typ.SortedSet.NumChunks = numChunks
 	case *types.ObjectMeta_ListItem:
 		typ.ListItem.NumChunks = numChunks
 	}

--- a/internal/server/redis/object.go
+++ b/internal/server/redis/object.go
@@ -23,7 +23,6 @@ type objectKind int64
 const (
 	objectKindBasic objectKind = 1 << iota
 	objectKindSet
-	objectKindSortedSet
 	objectKindList
 	objectKindListItem
 )
@@ -45,9 +44,6 @@ func getNumChunks(meta *types.ObjectMeta, kind gt.Option[objectKind]) (uint32, e
 	case *types.ObjectMeta_Set:
 		objKind = objectKindSet
 		numChunks = typ.Set.NumChunks
-	case *types.ObjectMeta_SortedSet:
-		objKind = objectKindSet
-		numChunks = typ.SortedSet.Set.NumChunks
 	case *types.ObjectMeta_ListItem:
 		objKind = objectKindListItem
 		numChunks = typ.ListItem.NumChunks
@@ -141,10 +137,6 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 			meta.Type = &types.ObjectMeta_Basic{Basic: &types.BasicObjectMeta{}}
 		case objectKindSet:
 			meta.Type = &types.ObjectMeta_Set{Set: &types.SetMeta{}}
-		case objectKindSortedSet:
-			meta.Type = &types.ObjectMeta_SortedSet{SortedSet: &types.SortedSetMeta{
-				Set: &types.SetMeta{},
-			}}
 		case objectKindListItem:
 			meta.Type = &types.ObjectMeta_ListItem{ListItem: &types.ListItemMeta{}}
 		}
@@ -165,8 +157,6 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 		typ.Basic.NumChunks = numChunks
 	case *types.ObjectMeta_Set:
 		typ.Set.NumChunks = numChunks
-	case *types.ObjectMeta_SortedSet:
-		typ.SortedSet.Set.NumChunks = numChunks
 	case *types.ObjectMeta_ListItem:
 		typ.ListItem.NumChunks = numChunks
 	}

--- a/internal/server/redis/object.go
+++ b/internal/server/redis/object.go
@@ -64,7 +64,7 @@ func (s *session) getObject(ctx context.Context, tx fdb.ReadTransaction, kind ob
 	ctx, span := s.tracer.Start(ctx, "getObject")
 	defer span.End()
 
-	_, meta, err := s.getObjectMeta(ctx, tx, id)
+	_, meta, err := s.getMeta(ctx, tx, id)
 	if err != nil {
 		span.RecordError(err)
 		return nil, nil, err
@@ -116,7 +116,7 @@ func (s *session) writeObject(ctx context.Context, tx fdb.Transaction, id string
 	now := timestamppb.Now()
 
 	// check if the object already exists and should be overwritten
-	metaKey, meta, err := s.getObjectMeta(ctx, tx, id)
+	metaKey, meta, err := s.getMeta(ctx, tx, id)
 	if err != nil {
 		span.RecordError(err)
 		return err
@@ -275,7 +275,7 @@ func (s *session) handleExists(ctx context.Context, args []resp.Value) (string, 
 	}
 
 	existsAny, err := s.fdb.ReadTransact(func(tx fdb.ReadTransaction) (any, error) {
-		_, meta, err := s.getObjectMeta(ctx, tx, key)
+		_, meta, err := s.getMeta(ctx, tx, key)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +337,7 @@ func (s *session) handleDelete(ctx context.Context, args []resp.Value) (string, 
 	}
 
 	existsAny, err := s.fdb.Transact(func(tx fdb.Transaction) (any, error) {
-		_, meta, err := s.getObjectMeta(ctx, tx, key)
+		_, meta, err := s.getMeta(ctx, tx, key)
 		if err != nil {
 			return false, err
 		}
@@ -578,7 +578,7 @@ func (s *session) handleExpire(ctx context.Context, args []resp.Value) (string, 
 	delta := time.Duration(secs) * time.Second
 
 	resAny, err := s.fdb.Transact(func(tx fdb.Transaction) (any, error) {
-		metaKey, meta, err := s.getObjectMeta(ctx, tx, key)
+		metaKey, meta, err := s.getMeta(ctx, tx, key)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get object meta: %w", err)
 		}

--- a/internal/server/redis/redis.go
+++ b/internal/server/redis/redis.go
@@ -399,6 +399,8 @@ func (s *session) handleCommand(ctx context.Context, cmd *resp.Command) string {
 		res, err = s.handleZAdd(ctx, cmd.Args)
 	case "zcount":
 		res, err = s.handleZCount(ctx, cmd.Args)
+	case "zremrangebyscore":
+		res, err = s.handleZRemRangeByScore(ctx, cmd.Args)
 	case "zcard":
 		res, err = s.handleSetCard(ctx, cmd.Args)
 	case "llen":
@@ -699,7 +701,8 @@ func (s *session) allocateNewUID(ctx context.Context, tx fdb.Transaction) (uint6
 	return newUID, nil
 }
 
-// Returns the UID for the given member string, creating a new one if it does not exist
+// Returns the UID for the given member string, creating a new one if it does not exist. If peek is true, it
+// will refuse to create a new UID if one does not already exist.
 func (s *session) getOrAllocateUID(ctx context.Context, tx fdb.Transaction, item *types.UIDItem) (uint64, error) {
 	ctx, span := s.tracer.Start(ctx, "getOrAllocateUID")
 	defer span.End()

--- a/internal/server/redis/redis.go
+++ b/internal/server/redis/redis.go
@@ -397,6 +397,8 @@ func (s *session) handleCommand(ctx context.Context, cmd *resp.Command) string {
 		res, err = s.handleSetDiff(ctx, cmd.Args)
 	case "zadd":
 		res, err = s.handleZAdd(ctx, cmd.Args)
+	case "zcount":
+		res, err = s.handleZCount(ctx, cmd.Args)
 	case "zcard":
 		res, err = s.handleSetCard(ctx, cmd.Args)
 	case "llen":

--- a/internal/server/redis/redis.go
+++ b/internal/server/redis/redis.go
@@ -722,13 +722,13 @@ func (s *session) getOrAllocateUID(ctx context.Context, tx fdb.Transaction, item
 
 	if len(val) == 0 {
 		// allocate a new UID for this member string
-		uid, err := s.allocateNewUID(ctx, tx)
+		item.Uid, err = s.allocateNewUID(ctx, tx)
 		if err != nil {
 			span.RecordError(err)
 			return 0, fmt.Errorf("failed to allocate new uid: %w", err)
 		}
 
-		uidStr := strconv.FormatUint(uid, 10)
+		uidStr := strconv.FormatUint(item.Uid, 10)
 		uidToMemberKey, err := s.uidKey(uidStr)
 		if err != nil {
 			span.RecordError(err)

--- a/internal/server/redis/redis_test.go
+++ b/internal/server/redis/redis_test.go
@@ -911,6 +911,7 @@ func TestOrderedSets(t *testing.T) {
 	score1 := "10"
 	val2 := testutil.RandString(24)
 	score2 := "20"
+	val3 := testutil.RandString(24)
 
 	// invalid arguments
 	res := sess.handleCommand(ctx, &resp.Command{
@@ -945,7 +946,7 @@ func TestOrderedSets(t *testing.T) {
 	})
 	requireRESPError(t, res)
 
-	// add both vals to the set
+	// add two vals to the set
 	res = sess.handleCommand(ctx, &resp.Command{
 		Name: "ZADD",
 		Args: []resp.Value{
@@ -1111,7 +1112,7 @@ func TestOrderedSets(t *testing.T) {
 	})
 	require.Equal(resp.FormatInt(0), res)
 
-	// delete should work
+	// add two items with the same score
 	res = sess.handleCommand(ctx, &resp.Command{
 		Name: "ZADD",
 		Args: []resp.Value{
@@ -1120,10 +1121,43 @@ func TestOrderedSets(t *testing.T) {
 			resp.BulkStringValue(val1),
 			resp.BulkStringValue(score2),
 			resp.BulkStringValue(val2),
+			resp.BulkStringValue(score2),
+			resp.BulkStringValue(val3),
+		},
+	})
+	require.Equal(resp.FormatInt(3), res)
+
+	res = sess.handleCommand(ctx, &resp.Command{
+		Name: "ZCOUNT",
+		Args: []resp.Value{
+			resp.SimpleStringValue(set1),
+			resp.BulkStringValue("-inf"),
+			resp.BulkStringValue("+inf"),
+		},
+	})
+	require.Equal(resp.FormatInt(3), res)
+
+	res = sess.handleCommand(ctx, &resp.Command{
+		Name: "ZREMRANGEBYSCORE",
+		Args: []resp.Value{
+			resp.SimpleStringValue(set1),
+			resp.BulkStringValue("19"),
+			resp.BulkStringValue("20"),
 		},
 	})
 	require.Equal(resp.FormatInt(2), res)
 
+	res = sess.handleCommand(ctx, &resp.Command{
+		Name: "ZCOUNT",
+		Args: []resp.Value{
+			resp.SimpleStringValue(set1),
+			resp.BulkStringValue("-inf"),
+			resp.BulkStringValue("+inf"),
+		},
+	})
+	require.Equal(resp.FormatInt(1), res)
+
+	// delete should work
 	res = sess.handleCommand(ctx, &resp.Command{
 		Name: "DEL",
 		Args: []resp.Value{resp.SimpleStringValue(set1)},

--- a/internal/server/redis/redis_test.go
+++ b/internal/server/redis/redis_test.go
@@ -901,6 +901,22 @@ func TestSets(t *testing.T) {
 	require.Equal(resp.FormatInt(1), res)
 }
 
+func TestEncodeSortedSetScore(t *testing.T) {
+	// spot check a couple values
+	require.Equal(t, []byte{0x40, 0x3f, 0xff, 0xff}, []byte(encodeSortedSetScore(-1.5)))
+	require.Equal(t, []byte{0xc0, 0x00, 0x00, 0x00}, []byte(encodeSortedSetScore(2.0)))
+
+	// perform many operations and ensure that sort order holds
+	f := float32(-100)
+	last := encodeSortedSetScore(f)
+	for range 100 {
+		f += 1.5
+		current := encodeSortedSetScore(f)
+		require.True(t, last < current)
+		last = current
+	}
+}
+
 func TestOrderedSets(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/server/redis/set.go
+++ b/internal/server/redis/set.go
@@ -662,7 +662,6 @@ func (s *session) handleZCount(ctx context.Context, args []resp.Value) (string, 
 			return uint64(0), fmt.Errorf("failed to get sorted set score dir: %w", err)
 		}
 
-		const limit = 1000
 		beginRange, endRange := dir.FDBRangeKeys()
 		rangeResult := tx.GetRange(fdb.KeyRange{Begin: beginRange, End: endRange}, fdb.RangeOptions{})
 

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -211,6 +211,7 @@ type ObjectMeta struct {
 	//
 	//	*ObjectMeta_Basic
 	//	*ObjectMeta_Set
+	//	*ObjectMeta_SortedSet
 	//	*ObjectMeta_List
 	//	*ObjectMeta_ListItem
 	Type          isObjectMeta_Type `protobuf_oneof:"type"`
@@ -294,6 +295,15 @@ func (x *ObjectMeta) GetSet() *SetMeta {
 	return nil
 }
 
+func (x *ObjectMeta) GetSortedSet() *SortedSetMeta {
+	if x != nil {
+		if x, ok := x.Type.(*ObjectMeta_SortedSet); ok {
+			return x.SortedSet
+		}
+	}
+	return nil
+}
+
 func (x *ObjectMeta) GetList() *ListMeta {
 	if x != nil {
 		if x, ok := x.Type.(*ObjectMeta_List); ok {
@@ -324,17 +334,23 @@ type ObjectMeta_Set struct {
 	Set *SetMeta `protobuf:"bytes,5,opt,name=set,proto3,oneof"`
 }
 
+type ObjectMeta_SortedSet struct {
+	SortedSet *SortedSetMeta `protobuf:"bytes,6,opt,name=sorted_set,json=sortedSet,proto3,oneof"`
+}
+
 type ObjectMeta_List struct {
-	List *ListMeta `protobuf:"bytes,6,opt,name=list,proto3,oneof"`
+	List *ListMeta `protobuf:"bytes,7,opt,name=list,proto3,oneof"`
 }
 
 type ObjectMeta_ListItem struct {
-	ListItem *ListItemMeta `protobuf:"bytes,7,opt,name=list_item,json=listItem,proto3,oneof"`
+	ListItem *ListItemMeta `protobuf:"bytes,8,opt,name=list_item,json=listItem,proto3,oneof"`
 }
 
 func (*ObjectMeta_Basic) isObjectMeta_Type() {}
 
 func (*ObjectMeta_Set) isObjectMeta_Type() {}
+
+func (*ObjectMeta_SortedSet) isObjectMeta_Type() {}
 
 func (*ObjectMeta_List) isObjectMeta_Type() {}
 
@@ -452,6 +468,66 @@ func (x *SetMeta) GetSizeBytes() uint64 {
 	return 0
 }
 
+type SortedSetMeta struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	NumItems      uint64                 `protobuf:"varint,1,opt,name=num_items,json=numItems,proto3" json:"num_items,omitempty"`
+	NumChunks     uint32                 `protobuf:"varint,2,opt,name=num_chunks,json=numChunks,proto3" json:"num_chunks,omitempty"`
+	SizeBytes     uint64                 `protobuf:"varint,3,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SortedSetMeta) Reset() {
+	*x = SortedSetMeta{}
+	mi := &file_redis_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SortedSetMeta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SortedSetMeta) ProtoMessage() {}
+
+func (x *SortedSetMeta) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SortedSetMeta.ProtoReflect.Descriptor instead.
+func (*SortedSetMeta) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SortedSetMeta) GetNumItems() uint64 {
+	if x != nil {
+		return x.NumItems
+	}
+	return 0
+}
+
+func (x *SortedSetMeta) GetNumChunks() uint32 {
+	if x != nil {
+		return x.NumChunks
+	}
+	return 0
+}
+
+func (x *SortedSetMeta) GetSizeBytes() uint64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
 type ListMeta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NumItems      uint64                 `protobuf:"varint,1,opt,name=num_items,json=numItems,proto3" json:"num_items,omitempty"`
@@ -463,7 +539,7 @@ type ListMeta struct {
 
 func (x *ListMeta) Reset() {
 	*x = ListMeta{}
-	mi := &file_redis_proto_msgTypes[5]
+	mi := &file_redis_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -475,7 +551,7 @@ func (x *ListMeta) String() string {
 func (*ListMeta) ProtoMessage() {}
 
 func (x *ListMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[5]
+	mi := &file_redis_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -488,7 +564,7 @@ func (x *ListMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMeta.ProtoReflect.Descriptor instead.
 func (*ListMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{5}
+	return file_redis_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListMeta) GetNumItems() uint64 {
@@ -525,7 +601,7 @@ type ListItemMeta struct {
 
 func (x *ListItemMeta) Reset() {
 	*x = ListItemMeta{}
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -537,7 +613,7 @@ func (x *ListItemMeta) String() string {
 func (*ListItemMeta) ProtoMessage() {}
 
 func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -550,7 +626,7 @@ func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemMeta.ProtoReflect.Descriptor instead.
 func (*ListItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{6}
+	return file_redis_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListItemMeta) GetId() string {
@@ -591,14 +667,15 @@ func (x *ListItemMeta) GetSizeBytes() uint64 {
 type UIDItem struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Member        string                 `protobuf:"bytes,1,opt,name=member,proto3" json:"member,omitempty"`
-	Score         *float32               `protobuf:"fixed32,2,opt,name=score,proto3,oneof" json:"score,omitempty"`
+	Uid           uint64                 `protobuf:"varint,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	Score         *float32               `protobuf:"fixed32,3,opt,name=score,proto3,oneof" json:"score,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UIDItem) Reset() {
 	*x = UIDItem{}
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -610,7 +687,7 @@ func (x *UIDItem) String() string {
 func (*UIDItem) ProtoMessage() {}
 
 func (x *UIDItem) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -623,7 +700,7 @@ func (x *UIDItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDItem.ProtoReflect.Descriptor instead.
 func (*UIDItem) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{7}
+	return file_redis_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *UIDItem) GetMember() string {
@@ -631,6 +708,13 @@ func (x *UIDItem) GetMember() string {
 		return x.Member
 	}
 	return ""
+}
+
+func (x *UIDItem) GetUid() uint64 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
 }
 
 func (x *UIDItem) GetScore() float32 {
@@ -654,16 +738,18 @@ const file_redis_proto_rawDesc = "" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12(\n" +
 	"\x05rules\x18\x06 \x03(\v2\x12.types.UserACLRuleR\x05rules\";\n" +
 	"\vUserACLRule\x12,\n" +
-	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xf6\x02\n" +
+	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xad\x03\n" +
 	"\n" +
 	"ObjectMeta\x124\n" +
 	"\acreated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x124\n" +
 	"\aupdated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\aupdated\x129\n" +
 	"\aexpires\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\aexpires\x88\x01\x01\x12.\n" +
 	"\x05basic\x18\x04 \x01(\v2\x16.types.BasicObjectMetaH\x00R\x05basic\x12\"\n" +
-	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x12%\n" +
-	"\x04list\x18\x06 \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
-	"\tlist_item\x18\a \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
+	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x125\n" +
+	"\n" +
+	"sorted_set\x18\x06 \x01(\v2\x14.types.SortedSetMetaH\x00R\tsortedSet\x12%\n" +
+	"\x04list\x18\a \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
+	"\tlist_item\x18\b \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
 	"\x04typeB\n" +
 	"\n" +
 	"\b_expires\"O\n" +
@@ -673,6 +759,12 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"size_bytes\x18\x02 \x01(\x04R\tsizeBytes\"d\n" +
 	"\aSetMeta\x12\x1b\n" +
+	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1d\n" +
+	"\n" +
+	"num_chunks\x18\x02 \x01(\rR\tnumChunks\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"j\n" +
+	"\rSortedSetMeta\x12\x1b\n" +
 	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1d\n" +
 	"\n" +
 	"num_chunks\x18\x02 \x01(\rR\tnumChunks\x12\x1d\n" +
@@ -689,10 +781,11 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x04 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x05 \x01(\x04R\tsizeBytes\"F\n" +
+	"size_bytes\x18\x05 \x01(\x04R\tsizeBytes\"X\n" +
 	"\aUIDItem\x12\x16\n" +
-	"\x06member\x18\x01 \x01(\tR\x06member\x12\x19\n" +
-	"\x05score\x18\x02 \x01(\x02H\x00R\x05score\x88\x01\x01B\b\n" +
+	"\x06member\x18\x01 \x01(\tR\x06member\x12\x10\n" +
+	"\x03uid\x18\x02 \x01(\x04R\x03uid\x12\x19\n" +
+	"\x05score\x18\x03 \x01(\x02H\x00R\x05score\x88\x01\x01B\b\n" +
 	"\x06_score*\x97\x01\n" +
 	"\x0fUserAccessLevel\x12!\n" +
 	"\x1dUSER_ACCESS_LEVEL_UNSPECIFIED\x10\x00\x12#\n" +
@@ -713,7 +806,7 @@ func file_redis_proto_rawDescGZIP() []byte {
 }
 
 var file_redis_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_redis_proto_goTypes = []any{
 	(UserAccessLevel)(0),          // 0: types.UserAccessLevel
 	(*User)(nil),                  // 1: types.User
@@ -721,28 +814,30 @@ var file_redis_proto_goTypes = []any{
 	(*ObjectMeta)(nil),            // 3: types.ObjectMeta
 	(*BasicObjectMeta)(nil),       // 4: types.BasicObjectMeta
 	(*SetMeta)(nil),               // 5: types.SetMeta
-	(*ListMeta)(nil),              // 6: types.ListMeta
-	(*ListItemMeta)(nil),          // 7: types.ListItemMeta
-	(*UIDItem)(nil),               // 8: types.UIDItem
-	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
+	(*SortedSetMeta)(nil),         // 6: types.SortedSetMeta
+	(*ListMeta)(nil),              // 7: types.ListMeta
+	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
+	(*UIDItem)(nil),               // 9: types.UIDItem
+	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
-	9,  // 0: types.User.created:type_name -> google.protobuf.Timestamp
-	9,  // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
+	10, // 0: types.User.created:type_name -> google.protobuf.Timestamp
+	10, // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
 	2,  // 2: types.User.rules:type_name -> types.UserACLRule
 	0,  // 3: types.UserACLRule.level:type_name -> types.UserAccessLevel
-	9,  // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
-	9,  // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
-	9,  // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
+	10, // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
+	10, // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
+	10, // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
-	6,  // 9: types.ObjectMeta.list:type_name -> types.ListMeta
-	7,  // 10: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	6,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
+	7,  // 10: types.ObjectMeta.list:type_name -> types.ListMeta
+	8,  // 11: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_redis_proto_init() }
@@ -753,17 +848,18 @@ func file_redis_proto_init() {
 	file_redis_proto_msgTypes[2].OneofWrappers = []any{
 		(*ObjectMeta_Basic)(nil),
 		(*ObjectMeta_Set)(nil),
+		(*ObjectMeta_SortedSet)(nil),
 		(*ObjectMeta_List)(nil),
 		(*ObjectMeta_ListItem)(nil),
 	}
-	file_redis_proto_msgTypes[7].OneofWrappers = []any{}
+	file_redis_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_redis_proto_rawDesc), len(file_redis_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -468,6 +468,110 @@ func (x *SetMeta) GetSizeBytes() uint64 {
 	return 0
 }
 
+type SetMember struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Uid           uint64                 `protobuf:"varint,1,opt,name=uid,proto3" json:"uid,omitempty"`
+	Member        string                 `protobuf:"bytes,2,opt,name=member,proto3" json:"member,omitempty"`
+	Score         *float32               `protobuf:"fixed32,3,opt,name=score,proto3,oneof" json:"score,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetMember) Reset() {
+	*x = SetMember{}
+	mi := &file_redis_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetMember) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetMember) ProtoMessage() {}
+
+func (x *SetMember) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetMember.ProtoReflect.Descriptor instead.
+func (*SetMember) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SetMember) GetUid() uint64 {
+	if x != nil {
+		return x.Uid
+	}
+	return 0
+}
+
+func (x *SetMember) GetMember() string {
+	if x != nil {
+		return x.Member
+	}
+	return ""
+}
+
+func (x *SetMember) GetScore() float32 {
+	if x != nil && x.Score != nil {
+		return *x.Score
+	}
+	return 0
+}
+
+type SetMembers struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Members       []*SetMember           `protobuf:"bytes,1,rep,name=members,proto3" json:"members,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetMembers) Reset() {
+	*x = SetMembers{}
+	mi := &file_redis_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetMembers) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetMembers) ProtoMessage() {}
+
+func (x *SetMembers) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetMembers.ProtoReflect.Descriptor instead.
+func (*SetMembers) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SetMembers) GetMembers() []*SetMember {
+	if x != nil {
+		return x.Members
+	}
+	return nil
+}
+
 type SortedSetMeta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NumItems      uint64                 `protobuf:"varint,1,opt,name=num_items,json=numItems,proto3" json:"num_items,omitempty"`
@@ -479,7 +583,7 @@ type SortedSetMeta struct {
 
 func (x *SortedSetMeta) Reset() {
 	*x = SortedSetMeta{}
-	mi := &file_redis_proto_msgTypes[5]
+	mi := &file_redis_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -491,7 +595,7 @@ func (x *SortedSetMeta) String() string {
 func (*SortedSetMeta) ProtoMessage() {}
 
 func (x *SortedSetMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[5]
+	mi := &file_redis_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -504,7 +608,7 @@ func (x *SortedSetMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SortedSetMeta.ProtoReflect.Descriptor instead.
 func (*SortedSetMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{5}
+	return file_redis_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SortedSetMeta) GetNumItems() uint64 {
@@ -539,7 +643,7 @@ type ListMeta struct {
 
 func (x *ListMeta) Reset() {
 	*x = ListMeta{}
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -551,7 +655,7 @@ func (x *ListMeta) String() string {
 func (*ListMeta) ProtoMessage() {}
 
 func (x *ListMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -564,7 +668,7 @@ func (x *ListMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMeta.ProtoReflect.Descriptor instead.
 func (*ListMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{6}
+	return file_redis_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListMeta) GetNumItems() uint64 {
@@ -601,7 +705,7 @@ type ListItemMeta struct {
 
 func (x *ListItemMeta) Reset() {
 	*x = ListItemMeta{}
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -613,7 +717,7 @@ func (x *ListItemMeta) String() string {
 func (*ListItemMeta) ProtoMessage() {}
 
 func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -626,7 +730,7 @@ func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemMeta.ProtoReflect.Descriptor instead.
 func (*ListItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{7}
+	return file_redis_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListItemMeta) GetId() string {
@@ -662,110 +766,6 @@ func (x *ListItemMeta) GetSizeBytes() uint64 {
 		return x.SizeBytes
 	}
 	return 0
-}
-
-type UIDItem struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Member        string                 `protobuf:"bytes,1,opt,name=member,proto3" json:"member,omitempty"`
-	Uid           uint64                 `protobuf:"varint,2,opt,name=uid,proto3" json:"uid,omitempty"`
-	Score         *float32               `protobuf:"fixed32,3,opt,name=score,proto3,oneof" json:"score,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *UIDItem) Reset() {
-	*x = UIDItem{}
-	mi := &file_redis_proto_msgTypes[8]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UIDItem) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UIDItem) ProtoMessage() {}
-
-func (x *UIDItem) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[8]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use UIDItem.ProtoReflect.Descriptor instead.
-func (*UIDItem) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{8}
-}
-
-func (x *UIDItem) GetMember() string {
-	if x != nil {
-		return x.Member
-	}
-	return ""
-}
-
-func (x *UIDItem) GetUid() uint64 {
-	if x != nil {
-		return x.Uid
-	}
-	return 0
-}
-
-func (x *UIDItem) GetScore() float32 {
-	if x != nil && x.Score != nil {
-		return *x.Score
-	}
-	return 0
-}
-
-type UIDItems struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Items         []*UIDItem             `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *UIDItems) Reset() {
-	*x = UIDItems{}
-	mi := &file_redis_proto_msgTypes[9]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UIDItems) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UIDItems) ProtoMessage() {}
-
-func (x *UIDItems) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[9]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use UIDItems.ProtoReflect.Descriptor instead.
-func (*UIDItems) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *UIDItems) GetItems() []*UIDItem {
-	if x != nil {
-		return x.Items
-	}
-	return nil
 }
 
 var File_redis_proto protoreflect.FileDescriptor
@@ -807,7 +807,15 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x02 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"j\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"Z\n" +
+	"\tSetMember\x12\x10\n" +
+	"\x03uid\x18\x01 \x01(\x04R\x03uid\x12\x16\n" +
+	"\x06member\x18\x02 \x01(\tR\x06member\x12\x19\n" +
+	"\x05score\x18\x03 \x01(\x02H\x00R\x05score\x88\x01\x01B\b\n" +
+	"\x06_score\"8\n" +
+	"\n" +
+	"SetMembers\x12*\n" +
+	"\amembers\x18\x01 \x03(\v2\x10.types.SetMemberR\amembers\"j\n" +
 	"\rSortedSetMeta\x12\x1b\n" +
 	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1d\n" +
 	"\n" +
@@ -825,14 +833,7 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x04 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x05 \x01(\x04R\tsizeBytes\"X\n" +
-	"\aUIDItem\x12\x16\n" +
-	"\x06member\x18\x01 \x01(\tR\x06member\x12\x10\n" +
-	"\x03uid\x18\x02 \x01(\x04R\x03uid\x12\x19\n" +
-	"\x05score\x18\x03 \x01(\x02H\x00R\x05score\x88\x01\x01B\b\n" +
-	"\x06_score\"0\n" +
-	"\bUIDItems\x12$\n" +
-	"\x05items\x18\x01 \x03(\v2\x0e.types.UIDItemR\x05items*\x97\x01\n" +
+	"size_bytes\x18\x05 \x01(\x04R\tsizeBytes*\x97\x01\n" +
 	"\x0fUserAccessLevel\x12!\n" +
 	"\x1dUSER_ACCESS_LEVEL_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fUSER_ACCESS_LEVEL_CLUSTER_ADMIN\x10\x01\x12 \n" +
@@ -860,11 +861,11 @@ var file_redis_proto_goTypes = []any{
 	(*ObjectMeta)(nil),            // 3: types.ObjectMeta
 	(*BasicObjectMeta)(nil),       // 4: types.BasicObjectMeta
 	(*SetMeta)(nil),               // 5: types.SetMeta
-	(*SortedSetMeta)(nil),         // 6: types.SortedSetMeta
-	(*ListMeta)(nil),              // 7: types.ListMeta
-	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
-	(*UIDItem)(nil),               // 9: types.UIDItem
-	(*UIDItems)(nil),              // 10: types.UIDItems
+	(*SetMember)(nil),             // 6: types.SetMember
+	(*SetMembers)(nil),            // 7: types.SetMembers
+	(*SortedSetMeta)(nil),         // 8: types.SortedSetMeta
+	(*ListMeta)(nil),              // 9: types.ListMeta
+	(*ListItemMeta)(nil),          // 10: types.ListItemMeta
 	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
@@ -877,10 +878,10 @@ var file_redis_proto_depIdxs = []int32{
 	11, // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
-	6,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
-	7,  // 10: types.ObjectMeta.list:type_name -> types.ListMeta
-	8,  // 11: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	9,  // 12: types.UIDItems.items:type_name -> types.UIDItem
+	8,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
+	9,  // 10: types.ObjectMeta.list:type_name -> types.ListMeta
+	10, // 11: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
+	6,  // 12: types.SetMembers.members:type_name -> types.SetMember
 	13, // [13:13] is the sub-list for method output_type
 	13, // [13:13] is the sub-list for method input_type
 	13, // [13:13] is the sub-list for extension type_name
@@ -900,7 +901,7 @@ func file_redis_proto_init() {
 		(*ObjectMeta_List)(nil),
 		(*ObjectMeta_ListItem)(nil),
 	}
-	file_redis_proto_msgTypes[8].OneofWrappers = []any{}
+	file_redis_proto_msgTypes[5].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -724,6 +724,50 @@ func (x *UIDItem) GetScore() float32 {
 	return 0
 }
 
+type UIDItems struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Items         []*UIDItem             `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UIDItems) Reset() {
+	*x = UIDItems{}
+	mi := &file_redis_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UIDItems) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UIDItems) ProtoMessage() {}
+
+func (x *UIDItems) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UIDItems.ProtoReflect.Descriptor instead.
+func (*UIDItems) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *UIDItems) GetItems() []*UIDItem {
+	if x != nil {
+		return x.Items
+	}
+	return nil
+}
+
 var File_redis_proto protoreflect.FileDescriptor
 
 const file_redis_proto_rawDesc = "" +
@@ -786,7 +830,9 @@ const file_redis_proto_rawDesc = "" +
 	"\x06member\x18\x01 \x01(\tR\x06member\x12\x10\n" +
 	"\x03uid\x18\x02 \x01(\x04R\x03uid\x12\x19\n" +
 	"\x05score\x18\x03 \x01(\x02H\x00R\x05score\x88\x01\x01B\b\n" +
-	"\x06_score*\x97\x01\n" +
+	"\x06_score\"0\n" +
+	"\bUIDItems\x12$\n" +
+	"\x05items\x18\x01 \x03(\v2\x0e.types.UIDItemR\x05items*\x97\x01\n" +
 	"\x0fUserAccessLevel\x12!\n" +
 	"\x1dUSER_ACCESS_LEVEL_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fUSER_ACCESS_LEVEL_CLUSTER_ADMIN\x10\x01\x12 \n" +
@@ -806,7 +852,7 @@ func file_redis_proto_rawDescGZIP() []byte {
 }
 
 var file_redis_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_redis_proto_goTypes = []any{
 	(UserAccessLevel)(0),          // 0: types.UserAccessLevel
 	(*User)(nil),                  // 1: types.User
@@ -818,26 +864,28 @@ var file_redis_proto_goTypes = []any{
 	(*ListMeta)(nil),              // 7: types.ListMeta
 	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
 	(*UIDItem)(nil),               // 9: types.UIDItem
-	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
+	(*UIDItems)(nil),              // 10: types.UIDItems
+	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
-	10, // 0: types.User.created:type_name -> google.protobuf.Timestamp
-	10, // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
+	11, // 0: types.User.created:type_name -> google.protobuf.Timestamp
+	11, // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
 	2,  // 2: types.User.rules:type_name -> types.UserACLRule
 	0,  // 3: types.UserACLRule.level:type_name -> types.UserAccessLevel
-	10, // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
-	10, // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
-	10, // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
+	11, // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
+	11, // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
+	11, // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
 	6,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
 	7,  // 10: types.ObjectMeta.list:type_name -> types.ListMeta
 	8,  // 11: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	9,  // 12: types.UIDItems.items:type_name -> types.UIDItem
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_redis_proto_init() }
@@ -859,7 +907,7 @@ func file_redis_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_redis_proto_rawDesc), len(file_redis_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -211,7 +211,6 @@ type ObjectMeta struct {
 	//
 	//	*ObjectMeta_Basic
 	//	*ObjectMeta_Set
-	//	*ObjectMeta_SortedSet
 	//	*ObjectMeta_List
 	//	*ObjectMeta_ListItem
 	Type          isObjectMeta_Type `protobuf_oneof:"type"`
@@ -295,15 +294,6 @@ func (x *ObjectMeta) GetSet() *SetMeta {
 	return nil
 }
 
-func (x *ObjectMeta) GetSortedSet() *SortedSetMeta {
-	if x != nil {
-		if x, ok := x.Type.(*ObjectMeta_SortedSet); ok {
-			return x.SortedSet
-		}
-	}
-	return nil
-}
-
 func (x *ObjectMeta) GetList() *ListMeta {
 	if x != nil {
 		if x, ok := x.Type.(*ObjectMeta_List); ok {
@@ -334,23 +324,17 @@ type ObjectMeta_Set struct {
 	Set *SetMeta `protobuf:"bytes,5,opt,name=set,proto3,oneof"`
 }
 
-type ObjectMeta_SortedSet struct {
-	SortedSet *SortedSetMeta `protobuf:"bytes,6,opt,name=sorted_set,json=sortedSet,proto3,oneof"`
-}
-
 type ObjectMeta_List struct {
-	List *ListMeta `protobuf:"bytes,7,opt,name=list,proto3,oneof"`
+	List *ListMeta `protobuf:"bytes,6,opt,name=list,proto3,oneof"`
 }
 
 type ObjectMeta_ListItem struct {
-	ListItem *ListItemMeta `protobuf:"bytes,8,opt,name=list_item,json=listItem,proto3,oneof"`
+	ListItem *ListItemMeta `protobuf:"bytes,7,opt,name=list_item,json=listItem,proto3,oneof"`
 }
 
 func (*ObjectMeta_Basic) isObjectMeta_Type() {}
 
 func (*ObjectMeta_Set) isObjectMeta_Type() {}
-
-func (*ObjectMeta_SortedSet) isObjectMeta_Type() {}
 
 func (*ObjectMeta_List) isObjectMeta_Type() {}
 
@@ -468,66 +452,6 @@ func (x *SetMeta) GetSizeBytes() uint64 {
 	return 0
 }
 
-type SortedSetMeta struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Set           *SetMeta               `protobuf:"bytes,1,opt,name=set,proto3" json:"set,omitempty"`
-	MinScore      float32                `protobuf:"fixed32,2,opt,name=min_score,json=minScore,proto3" json:"min_score,omitempty"`
-	MaxScore      float32                `protobuf:"fixed32,3,opt,name=max_score,json=maxScore,proto3" json:"max_score,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SortedSetMeta) Reset() {
-	*x = SortedSetMeta{}
-	mi := &file_redis_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SortedSetMeta) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SortedSetMeta) ProtoMessage() {}
-
-func (x *SortedSetMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SortedSetMeta.ProtoReflect.Descriptor instead.
-func (*SortedSetMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{5}
-}
-
-func (x *SortedSetMeta) GetSet() *SetMeta {
-	if x != nil {
-		return x.Set
-	}
-	return nil
-}
-
-func (x *SortedSetMeta) GetMinScore() float32 {
-	if x != nil {
-		return x.MinScore
-	}
-	return 0
-}
-
-func (x *SortedSetMeta) GetMaxScore() float32 {
-	if x != nil {
-		return x.MaxScore
-	}
-	return 0
-}
-
 type ListMeta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NumItems      uint64                 `protobuf:"varint,1,opt,name=num_items,json=numItems,proto3" json:"num_items,omitempty"`
@@ -539,7 +463,7 @@ type ListMeta struct {
 
 func (x *ListMeta) Reset() {
 	*x = ListMeta{}
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -551,7 +475,7 @@ func (x *ListMeta) String() string {
 func (*ListMeta) ProtoMessage() {}
 
 func (x *ListMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -564,7 +488,7 @@ func (x *ListMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMeta.ProtoReflect.Descriptor instead.
 func (*ListMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{6}
+	return file_redis_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ListMeta) GetNumItems() uint64 {
@@ -601,7 +525,7 @@ type ListItemMeta struct {
 
 func (x *ListItemMeta) Reset() {
 	*x = ListItemMeta{}
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -613,7 +537,7 @@ func (x *ListItemMeta) String() string {
 func (*ListItemMeta) ProtoMessage() {}
 
 func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -626,7 +550,7 @@ func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemMeta.ProtoReflect.Descriptor instead.
 func (*ListItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{7}
+	return file_redis_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListItemMeta) GetId() string {
@@ -674,7 +598,7 @@ type UIDItem struct {
 
 func (x *UIDItem) Reset() {
 	*x = UIDItem{}
-	mi := &file_redis_proto_msgTypes[8]
+	mi := &file_redis_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -686,7 +610,7 @@ func (x *UIDItem) String() string {
 func (*UIDItem) ProtoMessage() {}
 
 func (x *UIDItem) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[8]
+	mi := &file_redis_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -699,7 +623,7 @@ func (x *UIDItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIDItem.ProtoReflect.Descriptor instead.
 func (*UIDItem) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{8}
+	return file_redis_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *UIDItem) GetMember() string {
@@ -730,18 +654,16 @@ const file_redis_proto_rawDesc = "" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12(\n" +
 	"\x05rules\x18\x06 \x03(\v2\x12.types.UserACLRuleR\x05rules\";\n" +
 	"\vUserACLRule\x12,\n" +
-	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xad\x03\n" +
+	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xf6\x02\n" +
 	"\n" +
 	"ObjectMeta\x124\n" +
 	"\acreated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x124\n" +
 	"\aupdated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\aupdated\x129\n" +
 	"\aexpires\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\aexpires\x88\x01\x01\x12.\n" +
 	"\x05basic\x18\x04 \x01(\v2\x16.types.BasicObjectMetaH\x00R\x05basic\x12\"\n" +
-	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x125\n" +
-	"\n" +
-	"sorted_set\x18\x06 \x01(\v2\x14.types.SortedSetMetaH\x00R\tsortedSet\x12%\n" +
-	"\x04list\x18\a \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
-	"\tlist_item\x18\b \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
+	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x12%\n" +
+	"\x04list\x18\x06 \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
+	"\tlist_item\x18\a \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
 	"\x04typeB\n" +
 	"\n" +
 	"\b_expires\"O\n" +
@@ -755,11 +677,7 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x02 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"k\n" +
-	"\rSortedSetMeta\x12 \n" +
-	"\x03set\x18\x01 \x01(\v2\x0e.types.SetMetaR\x03set\x12\x1b\n" +
-	"\tmin_score\x18\x02 \x01(\x02R\bminScore\x12\x1b\n" +
-	"\tmax_score\x18\x03 \x01(\x02R\bmaxScore\"a\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"a\n" +
 	"\bListMeta\x12\x1b\n" +
 	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1b\n" +
 	"\titem_head\x18\x02 \x01(\tR\bitemHead\x12\x1b\n" +
@@ -795,7 +713,7 @@ func file_redis_proto_rawDescGZIP() []byte {
 }
 
 var file_redis_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_redis_proto_goTypes = []any{
 	(UserAccessLevel)(0),          // 0: types.UserAccessLevel
 	(*User)(nil),                  // 1: types.User
@@ -803,31 +721,28 @@ var file_redis_proto_goTypes = []any{
 	(*ObjectMeta)(nil),            // 3: types.ObjectMeta
 	(*BasicObjectMeta)(nil),       // 4: types.BasicObjectMeta
 	(*SetMeta)(nil),               // 5: types.SetMeta
-	(*SortedSetMeta)(nil),         // 6: types.SortedSetMeta
-	(*ListMeta)(nil),              // 7: types.ListMeta
-	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
-	(*UIDItem)(nil),               // 9: types.UIDItem
-	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
+	(*ListMeta)(nil),              // 6: types.ListMeta
+	(*ListItemMeta)(nil),          // 7: types.ListItemMeta
+	(*UIDItem)(nil),               // 8: types.UIDItem
+	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
-	10, // 0: types.User.created:type_name -> google.protobuf.Timestamp
-	10, // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
+	9,  // 0: types.User.created:type_name -> google.protobuf.Timestamp
+	9,  // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
 	2,  // 2: types.User.rules:type_name -> types.UserACLRule
 	0,  // 3: types.UserACLRule.level:type_name -> types.UserAccessLevel
-	10, // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
-	10, // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
-	10, // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
+	9,  // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
+	9,  // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
+	9,  // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
-	6,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
-	7,  // 10: types.ObjectMeta.list:type_name -> types.ListMeta
-	8,  // 11: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	5,  // 12: types.SortedSetMeta.set:type_name -> types.SetMeta
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	6,  // 9: types.ObjectMeta.list:type_name -> types.ListMeta
+	7,  // 10: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_redis_proto_init() }
@@ -838,18 +753,17 @@ func file_redis_proto_init() {
 	file_redis_proto_msgTypes[2].OneofWrappers = []any{
 		(*ObjectMeta_Basic)(nil),
 		(*ObjectMeta_Set)(nil),
-		(*ObjectMeta_SortedSet)(nil),
 		(*ObjectMeta_List)(nil),
 		(*ObjectMeta_ListItem)(nil),
 	}
-	file_redis_proto_msgTypes[8].OneofWrappers = []any{}
+	file_redis_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_redis_proto_rawDesc), len(file_redis_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   9,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -452,6 +452,66 @@ func (x *SetMeta) GetSizeBytes() uint64 {
 	return 0
 }
 
+type SortedSetMeta struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Set           *SetMeta               `protobuf:"bytes,1,opt,name=set,proto3" json:"set,omitempty"`
+	Min           float32                `protobuf:"fixed32,2,opt,name=min,proto3" json:"min,omitempty"`
+	Max           float32                `protobuf:"fixed32,3,opt,name=max,proto3" json:"max,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SortedSetMeta) Reset() {
+	*x = SortedSetMeta{}
+	mi := &file_redis_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SortedSetMeta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SortedSetMeta) ProtoMessage() {}
+
+func (x *SortedSetMeta) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SortedSetMeta.ProtoReflect.Descriptor instead.
+func (*SortedSetMeta) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SortedSetMeta) GetSet() *SetMeta {
+	if x != nil {
+		return x.Set
+	}
+	return nil
+}
+
+func (x *SortedSetMeta) GetMin() float32 {
+	if x != nil {
+		return x.Min
+	}
+	return 0
+}
+
+func (x *SortedSetMeta) GetMax() float32 {
+	if x != nil {
+		return x.Max
+	}
+	return 0
+}
+
 type ListMeta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NumItems      uint64                 `protobuf:"varint,1,opt,name=num_items,json=numItems,proto3" json:"num_items,omitempty"`
@@ -463,7 +523,7 @@ type ListMeta struct {
 
 func (x *ListMeta) Reset() {
 	*x = ListMeta{}
-	mi := &file_redis_proto_msgTypes[5]
+	mi := &file_redis_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -475,7 +535,7 @@ func (x *ListMeta) String() string {
 func (*ListMeta) ProtoMessage() {}
 
 func (x *ListMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[5]
+	mi := &file_redis_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -488,7 +548,7 @@ func (x *ListMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMeta.ProtoReflect.Descriptor instead.
 func (*ListMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{5}
+	return file_redis_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListMeta) GetNumItems() uint64 {
@@ -525,7 +585,7 @@ type ListItemMeta struct {
 
 func (x *ListItemMeta) Reset() {
 	*x = ListItemMeta{}
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -537,7 +597,7 @@ func (x *ListItemMeta) String() string {
 func (*ListItemMeta) ProtoMessage() {}
 
 func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -550,7 +610,7 @@ func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemMeta.ProtoReflect.Descriptor instead.
 func (*ListItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{6}
+	return file_redis_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListItemMeta) GetId() string {
@@ -625,7 +685,11 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x02 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"a\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"U\n" +
+	"\rSortedSetMeta\x12 \n" +
+	"\x03set\x18\x01 \x01(\v2\x0e.types.SetMetaR\x03set\x12\x10\n" +
+	"\x03min\x18\x02 \x01(\x02R\x03min\x12\x10\n" +
+	"\x03max\x18\x03 \x01(\x02R\x03max\"a\n" +
 	"\bListMeta\x12\x1b\n" +
 	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1b\n" +
 	"\titem_head\x18\x02 \x01(\tR\bitemHead\x12\x1b\n" +
@@ -657,7 +721,7 @@ func file_redis_proto_rawDescGZIP() []byte {
 }
 
 var file_redis_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_redis_proto_goTypes = []any{
 	(UserAccessLevel)(0),          // 0: types.UserAccessLevel
 	(*User)(nil),                  // 1: types.User
@@ -665,27 +729,29 @@ var file_redis_proto_goTypes = []any{
 	(*ObjectMeta)(nil),            // 3: types.ObjectMeta
 	(*BasicObjectMeta)(nil),       // 4: types.BasicObjectMeta
 	(*SetMeta)(nil),               // 5: types.SetMeta
-	(*ListMeta)(nil),              // 6: types.ListMeta
-	(*ListItemMeta)(nil),          // 7: types.ListItemMeta
-	(*timestamppb.Timestamp)(nil), // 8: google.protobuf.Timestamp
+	(*SortedSetMeta)(nil),         // 6: types.SortedSetMeta
+	(*ListMeta)(nil),              // 7: types.ListMeta
+	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
+	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
-	8,  // 0: types.User.created:type_name -> google.protobuf.Timestamp
-	8,  // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
+	9,  // 0: types.User.created:type_name -> google.protobuf.Timestamp
+	9,  // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
 	2,  // 2: types.User.rules:type_name -> types.UserACLRule
 	0,  // 3: types.UserACLRule.level:type_name -> types.UserAccessLevel
-	8,  // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
-	8,  // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
-	8,  // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
+	9,  // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
+	9,  // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
+	9,  // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
-	6,  // 9: types.ObjectMeta.list:type_name -> types.ListMeta
-	7,  // 10: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	7,  // 9: types.ObjectMeta.list:type_name -> types.ListMeta
+	8,  // 10: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
+	5,  // 11: types.SortedSetMeta.set:type_name -> types.SetMeta
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_redis_proto_init() }
@@ -705,7 +771,7 @@ func file_redis_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_redis_proto_rawDesc), len(file_redis_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -212,7 +212,6 @@ type ObjectMeta struct {
 	//	*ObjectMeta_Basic
 	//	*ObjectMeta_Set
 	//	*ObjectMeta_SortedSet
-	//	*ObjectMeta_SortedSetItem
 	//	*ObjectMeta_List
 	//	*ObjectMeta_ListItem
 	Type          isObjectMeta_Type `protobuf_oneof:"type"`
@@ -305,15 +304,6 @@ func (x *ObjectMeta) GetSortedSet() *SortedSetMeta {
 	return nil
 }
 
-func (x *ObjectMeta) GetSortedSetItem() *SortedSetItemMeta {
-	if x != nil {
-		if x, ok := x.Type.(*ObjectMeta_SortedSetItem); ok {
-			return x.SortedSetItem
-		}
-	}
-	return nil
-}
-
 func (x *ObjectMeta) GetList() *ListMeta {
 	if x != nil {
 		if x, ok := x.Type.(*ObjectMeta_List); ok {
@@ -348,16 +338,12 @@ type ObjectMeta_SortedSet struct {
 	SortedSet *SortedSetMeta `protobuf:"bytes,6,opt,name=sorted_set,json=sortedSet,proto3,oneof"`
 }
 
-type ObjectMeta_SortedSetItem struct {
-	SortedSetItem *SortedSetItemMeta `protobuf:"bytes,7,opt,name=sorted_set_item,json=sortedSetItem,proto3,oneof"`
-}
-
 type ObjectMeta_List struct {
-	List *ListMeta `protobuf:"bytes,8,opt,name=list,proto3,oneof"`
+	List *ListMeta `protobuf:"bytes,7,opt,name=list,proto3,oneof"`
 }
 
 type ObjectMeta_ListItem struct {
-	ListItem *ListItemMeta `protobuf:"bytes,9,opt,name=list_item,json=listItem,proto3,oneof"`
+	ListItem *ListItemMeta `protobuf:"bytes,8,opt,name=list_item,json=listItem,proto3,oneof"`
 }
 
 func (*ObjectMeta_Basic) isObjectMeta_Type() {}
@@ -365,8 +351,6 @@ func (*ObjectMeta_Basic) isObjectMeta_Type() {}
 func (*ObjectMeta_Set) isObjectMeta_Type() {}
 
 func (*ObjectMeta_SortedSet) isObjectMeta_Type() {}
-
-func (*ObjectMeta_SortedSetItem) isObjectMeta_Type() {}
 
 func (*ObjectMeta_List) isObjectMeta_Type() {}
 
@@ -544,58 +528,6 @@ func (x *SortedSetMeta) GetMaxScore() float32 {
 	return 0
 }
 
-type SortedSetItemMeta struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Object        *BasicObjectMeta       `protobuf:"bytes,1,opt,name=object,proto3" json:"object,omitempty"`
-	Score         float32                `protobuf:"fixed32,2,opt,name=score,proto3" json:"score,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *SortedSetItemMeta) Reset() {
-	*x = SortedSetItemMeta{}
-	mi := &file_redis_proto_msgTypes[6]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *SortedSetItemMeta) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*SortedSetItemMeta) ProtoMessage() {}
-
-func (x *SortedSetItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[6]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use SortedSetItemMeta.ProtoReflect.Descriptor instead.
-func (*SortedSetItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{6}
-}
-
-func (x *SortedSetItemMeta) GetObject() *BasicObjectMeta {
-	if x != nil {
-		return x.Object
-	}
-	return nil
-}
-
-func (x *SortedSetItemMeta) GetScore() float32 {
-	if x != nil {
-		return x.Score
-	}
-	return 0
-}
-
 type ListMeta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	NumItems      uint64                 `protobuf:"varint,1,opt,name=num_items,json=numItems,proto3" json:"num_items,omitempty"`
@@ -607,7 +539,7 @@ type ListMeta struct {
 
 func (x *ListMeta) Reset() {
 	*x = ListMeta{}
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -619,7 +551,7 @@ func (x *ListMeta) String() string {
 func (*ListMeta) ProtoMessage() {}
 
 func (x *ListMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -632,7 +564,7 @@ func (x *ListMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMeta.ProtoReflect.Descriptor instead.
 func (*ListMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{7}
+	return file_redis_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListMeta) GetNumItems() uint64 {
@@ -669,7 +601,7 @@ type ListItemMeta struct {
 
 func (x *ListItemMeta) Reset() {
 	*x = ListItemMeta{}
-	mi := &file_redis_proto_msgTypes[8]
+	mi := &file_redis_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -681,7 +613,7 @@ func (x *ListItemMeta) String() string {
 func (*ListItemMeta) ProtoMessage() {}
 
 func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[8]
+	mi := &file_redis_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -694,7 +626,7 @@ func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemMeta.ProtoReflect.Descriptor instead.
 func (*ListItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{8}
+	return file_redis_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListItemMeta) GetId() string {
@@ -732,6 +664,58 @@ func (x *ListItemMeta) GetSizeBytes() uint64 {
 	return 0
 }
 
+type UIDItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Member        string                 `protobuf:"bytes,1,opt,name=member,proto3" json:"member,omitempty"`
+	Score         *float32               `protobuf:"fixed32,2,opt,name=score,proto3,oneof" json:"score,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UIDItem) Reset() {
+	*x = UIDItem{}
+	mi := &file_redis_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UIDItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UIDItem) ProtoMessage() {}
+
+func (x *UIDItem) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UIDItem.ProtoReflect.Descriptor instead.
+func (*UIDItem) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *UIDItem) GetMember() string {
+	if x != nil {
+		return x.Member
+	}
+	return ""
+}
+
+func (x *UIDItem) GetScore() float32 {
+	if x != nil && x.Score != nil {
+		return *x.Score
+	}
+	return 0
+}
+
 var File_redis_proto protoreflect.FileDescriptor
 
 const file_redis_proto_rawDesc = "" +
@@ -746,7 +730,7 @@ const file_redis_proto_rawDesc = "" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12(\n" +
 	"\x05rules\x18\x06 \x03(\v2\x12.types.UserACLRuleR\x05rules\";\n" +
 	"\vUserACLRule\x12,\n" +
-	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xf1\x03\n" +
+	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xad\x03\n" +
 	"\n" +
 	"ObjectMeta\x124\n" +
 	"\acreated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x124\n" +
@@ -755,10 +739,9 @@ const file_redis_proto_rawDesc = "" +
 	"\x05basic\x18\x04 \x01(\v2\x16.types.BasicObjectMetaH\x00R\x05basic\x12\"\n" +
 	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x125\n" +
 	"\n" +
-	"sorted_set\x18\x06 \x01(\v2\x14.types.SortedSetMetaH\x00R\tsortedSet\x12B\n" +
-	"\x0fsorted_set_item\x18\a \x01(\v2\x18.types.SortedSetItemMetaH\x00R\rsortedSetItem\x12%\n" +
-	"\x04list\x18\b \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
-	"\tlist_item\x18\t \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
+	"sorted_set\x18\x06 \x01(\v2\x14.types.SortedSetMetaH\x00R\tsortedSet\x12%\n" +
+	"\x04list\x18\a \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
+	"\tlist_item\x18\b \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
 	"\x04typeB\n" +
 	"\n" +
 	"\b_expires\"O\n" +
@@ -776,10 +759,7 @@ const file_redis_proto_rawDesc = "" +
 	"\rSortedSetMeta\x12 \n" +
 	"\x03set\x18\x01 \x01(\v2\x0e.types.SetMetaR\x03set\x12\x1b\n" +
 	"\tmin_score\x18\x02 \x01(\x02R\bminScore\x12\x1b\n" +
-	"\tmax_score\x18\x03 \x01(\x02R\bmaxScore\"Y\n" +
-	"\x11SortedSetItemMeta\x12.\n" +
-	"\x06object\x18\x01 \x01(\v2\x16.types.BasicObjectMetaR\x06object\x12\x14\n" +
-	"\x05score\x18\x02 \x01(\x02R\x05score\"a\n" +
+	"\tmax_score\x18\x03 \x01(\x02R\bmaxScore\"a\n" +
 	"\bListMeta\x12\x1b\n" +
 	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1b\n" +
 	"\titem_head\x18\x02 \x01(\tR\bitemHead\x12\x1b\n" +
@@ -791,7 +771,11 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x04 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x05 \x01(\x04R\tsizeBytes*\x97\x01\n" +
+	"size_bytes\x18\x05 \x01(\x04R\tsizeBytes\"F\n" +
+	"\aUIDItem\x12\x16\n" +
+	"\x06member\x18\x01 \x01(\tR\x06member\x12\x19\n" +
+	"\x05score\x18\x02 \x01(\x02H\x00R\x05score\x88\x01\x01B\b\n" +
+	"\x06_score*\x97\x01\n" +
 	"\x0fUserAccessLevel\x12!\n" +
 	"\x1dUSER_ACCESS_LEVEL_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fUSER_ACCESS_LEVEL_CLUSTER_ADMIN\x10\x01\x12 \n" +
@@ -820,9 +804,9 @@ var file_redis_proto_goTypes = []any{
 	(*BasicObjectMeta)(nil),       // 4: types.BasicObjectMeta
 	(*SetMeta)(nil),               // 5: types.SetMeta
 	(*SortedSetMeta)(nil),         // 6: types.SortedSetMeta
-	(*SortedSetItemMeta)(nil),     // 7: types.SortedSetItemMeta
-	(*ListMeta)(nil),              // 8: types.ListMeta
-	(*ListItemMeta)(nil),          // 9: types.ListItemMeta
+	(*ListMeta)(nil),              // 7: types.ListMeta
+	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
+	(*UIDItem)(nil),               // 9: types.UIDItem
 	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
@@ -836,16 +820,14 @@ var file_redis_proto_depIdxs = []int32{
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
 	6,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
-	7,  // 10: types.ObjectMeta.sorted_set_item:type_name -> types.SortedSetItemMeta
-	8,  // 11: types.ObjectMeta.list:type_name -> types.ListMeta
-	9,  // 12: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	5,  // 13: types.SortedSetMeta.set:type_name -> types.SetMeta
-	4,  // 14: types.SortedSetItemMeta.object:type_name -> types.BasicObjectMeta
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	7,  // 10: types.ObjectMeta.list:type_name -> types.ListMeta
+	8,  // 11: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
+	5,  // 12: types.SortedSetMeta.set:type_name -> types.SetMeta
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_redis_proto_init() }
@@ -857,10 +839,10 @@ func file_redis_proto_init() {
 		(*ObjectMeta_Basic)(nil),
 		(*ObjectMeta_Set)(nil),
 		(*ObjectMeta_SortedSet)(nil),
-		(*ObjectMeta_SortedSetItem)(nil),
 		(*ObjectMeta_List)(nil),
 		(*ObjectMeta_ListItem)(nil),
 	}
+	file_redis_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/internal/types/redis.pb.go
+++ b/internal/types/redis.pb.go
@@ -211,6 +211,8 @@ type ObjectMeta struct {
 	//
 	//	*ObjectMeta_Basic
 	//	*ObjectMeta_Set
+	//	*ObjectMeta_SortedSet
+	//	*ObjectMeta_SortedSetItem
 	//	*ObjectMeta_List
 	//	*ObjectMeta_ListItem
 	Type          isObjectMeta_Type `protobuf_oneof:"type"`
@@ -294,6 +296,24 @@ func (x *ObjectMeta) GetSet() *SetMeta {
 	return nil
 }
 
+func (x *ObjectMeta) GetSortedSet() *SortedSetMeta {
+	if x != nil {
+		if x, ok := x.Type.(*ObjectMeta_SortedSet); ok {
+			return x.SortedSet
+		}
+	}
+	return nil
+}
+
+func (x *ObjectMeta) GetSortedSetItem() *SortedSetItemMeta {
+	if x != nil {
+		if x, ok := x.Type.(*ObjectMeta_SortedSetItem); ok {
+			return x.SortedSetItem
+		}
+	}
+	return nil
+}
+
 func (x *ObjectMeta) GetList() *ListMeta {
 	if x != nil {
 		if x, ok := x.Type.(*ObjectMeta_List); ok {
@@ -324,17 +344,29 @@ type ObjectMeta_Set struct {
 	Set *SetMeta `protobuf:"bytes,5,opt,name=set,proto3,oneof"`
 }
 
+type ObjectMeta_SortedSet struct {
+	SortedSet *SortedSetMeta `protobuf:"bytes,6,opt,name=sorted_set,json=sortedSet,proto3,oneof"`
+}
+
+type ObjectMeta_SortedSetItem struct {
+	SortedSetItem *SortedSetItemMeta `protobuf:"bytes,7,opt,name=sorted_set_item,json=sortedSetItem,proto3,oneof"`
+}
+
 type ObjectMeta_List struct {
-	List *ListMeta `protobuf:"bytes,6,opt,name=list,proto3,oneof"`
+	List *ListMeta `protobuf:"bytes,8,opt,name=list,proto3,oneof"`
 }
 
 type ObjectMeta_ListItem struct {
-	ListItem *ListItemMeta `protobuf:"bytes,7,opt,name=list_item,json=listItem,proto3,oneof"`
+	ListItem *ListItemMeta `protobuf:"bytes,9,opt,name=list_item,json=listItem,proto3,oneof"`
 }
 
 func (*ObjectMeta_Basic) isObjectMeta_Type() {}
 
 func (*ObjectMeta_Set) isObjectMeta_Type() {}
+
+func (*ObjectMeta_SortedSet) isObjectMeta_Type() {}
+
+func (*ObjectMeta_SortedSetItem) isObjectMeta_Type() {}
 
 func (*ObjectMeta_List) isObjectMeta_Type() {}
 
@@ -455,8 +487,8 @@ func (x *SetMeta) GetSizeBytes() uint64 {
 type SortedSetMeta struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Set           *SetMeta               `protobuf:"bytes,1,opt,name=set,proto3" json:"set,omitempty"`
-	Min           float32                `protobuf:"fixed32,2,opt,name=min,proto3" json:"min,omitempty"`
-	Max           float32                `protobuf:"fixed32,3,opt,name=max,proto3" json:"max,omitempty"`
+	MinScore      float32                `protobuf:"fixed32,2,opt,name=min_score,json=minScore,proto3" json:"min_score,omitempty"`
+	MaxScore      float32                `protobuf:"fixed32,3,opt,name=max_score,json=maxScore,proto3" json:"max_score,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -498,16 +530,68 @@ func (x *SortedSetMeta) GetSet() *SetMeta {
 	return nil
 }
 
-func (x *SortedSetMeta) GetMin() float32 {
+func (x *SortedSetMeta) GetMinScore() float32 {
 	if x != nil {
-		return x.Min
+		return x.MinScore
 	}
 	return 0
 }
 
-func (x *SortedSetMeta) GetMax() float32 {
+func (x *SortedSetMeta) GetMaxScore() float32 {
 	if x != nil {
-		return x.Max
+		return x.MaxScore
+	}
+	return 0
+}
+
+type SortedSetItemMeta struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Object        *BasicObjectMeta       `protobuf:"bytes,1,opt,name=object,proto3" json:"object,omitempty"`
+	Score         float32                `protobuf:"fixed32,2,opt,name=score,proto3" json:"score,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SortedSetItemMeta) Reset() {
+	*x = SortedSetItemMeta{}
+	mi := &file_redis_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SortedSetItemMeta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SortedSetItemMeta) ProtoMessage() {}
+
+func (x *SortedSetItemMeta) ProtoReflect() protoreflect.Message {
+	mi := &file_redis_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SortedSetItemMeta.ProtoReflect.Descriptor instead.
+func (*SortedSetItemMeta) Descriptor() ([]byte, []int) {
+	return file_redis_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SortedSetItemMeta) GetObject() *BasicObjectMeta {
+	if x != nil {
+		return x.Object
+	}
+	return nil
+}
+
+func (x *SortedSetItemMeta) GetScore() float32 {
+	if x != nil {
+		return x.Score
 	}
 	return 0
 }
@@ -523,7 +607,7 @@ type ListMeta struct {
 
 func (x *ListMeta) Reset() {
 	*x = ListMeta{}
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -535,7 +619,7 @@ func (x *ListMeta) String() string {
 func (*ListMeta) ProtoMessage() {}
 
 func (x *ListMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[6]
+	mi := &file_redis_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -548,7 +632,7 @@ func (x *ListMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMeta.ProtoReflect.Descriptor instead.
 func (*ListMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{6}
+	return file_redis_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListMeta) GetNumItems() uint64 {
@@ -585,7 +669,7 @@ type ListItemMeta struct {
 
 func (x *ListItemMeta) Reset() {
 	*x = ListItemMeta{}
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -597,7 +681,7 @@ func (x *ListItemMeta) String() string {
 func (*ListItemMeta) ProtoMessage() {}
 
 func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_redis_proto_msgTypes[7]
+	mi := &file_redis_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -610,7 +694,7 @@ func (x *ListItemMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListItemMeta.ProtoReflect.Descriptor instead.
 func (*ListItemMeta) Descriptor() ([]byte, []int) {
-	return file_redis_proto_rawDescGZIP(), []int{7}
+	return file_redis_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListItemMeta) GetId() string {
@@ -662,16 +746,19 @@ const file_redis_proto_rawDesc = "" +
 	"\aenabled\x18\x05 \x01(\bR\aenabled\x12(\n" +
 	"\x05rules\x18\x06 \x03(\v2\x12.types.UserACLRuleR\x05rules\";\n" +
 	"\vUserACLRule\x12,\n" +
-	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xf6\x02\n" +
+	"\x05level\x18\x01 \x01(\x0e2\x16.types.UserAccessLevelR\x05level\"\xf1\x03\n" +
 	"\n" +
 	"ObjectMeta\x124\n" +
 	"\acreated\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x124\n" +
 	"\aupdated\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\aupdated\x129\n" +
 	"\aexpires\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\aexpires\x88\x01\x01\x12.\n" +
 	"\x05basic\x18\x04 \x01(\v2\x16.types.BasicObjectMetaH\x00R\x05basic\x12\"\n" +
-	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x12%\n" +
-	"\x04list\x18\x06 \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
-	"\tlist_item\x18\a \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
+	"\x03set\x18\x05 \x01(\v2\x0e.types.SetMetaH\x00R\x03set\x125\n" +
+	"\n" +
+	"sorted_set\x18\x06 \x01(\v2\x14.types.SortedSetMetaH\x00R\tsortedSet\x12B\n" +
+	"\x0fsorted_set_item\x18\a \x01(\v2\x18.types.SortedSetItemMetaH\x00R\rsortedSetItem\x12%\n" +
+	"\x04list\x18\b \x01(\v2\x0f.types.ListMetaH\x00R\x04list\x122\n" +
+	"\tlist_item\x18\t \x01(\v2\x13.types.ListItemMetaH\x00R\blistItemB\x06\n" +
 	"\x04typeB\n" +
 	"\n" +
 	"\b_expires\"O\n" +
@@ -685,11 +772,14 @@ const file_redis_proto_rawDesc = "" +
 	"\n" +
 	"num_chunks\x18\x02 \x01(\rR\tnumChunks\x12\x1d\n" +
 	"\n" +
-	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"U\n" +
+	"size_bytes\x18\x03 \x01(\x04R\tsizeBytes\"k\n" +
 	"\rSortedSetMeta\x12 \n" +
-	"\x03set\x18\x01 \x01(\v2\x0e.types.SetMetaR\x03set\x12\x10\n" +
-	"\x03min\x18\x02 \x01(\x02R\x03min\x12\x10\n" +
-	"\x03max\x18\x03 \x01(\x02R\x03max\"a\n" +
+	"\x03set\x18\x01 \x01(\v2\x0e.types.SetMetaR\x03set\x12\x1b\n" +
+	"\tmin_score\x18\x02 \x01(\x02R\bminScore\x12\x1b\n" +
+	"\tmax_score\x18\x03 \x01(\x02R\bmaxScore\"Y\n" +
+	"\x11SortedSetItemMeta\x12.\n" +
+	"\x06object\x18\x01 \x01(\v2\x16.types.BasicObjectMetaR\x06object\x12\x14\n" +
+	"\x05score\x18\x02 \x01(\x02R\x05score\"a\n" +
 	"\bListMeta\x12\x1b\n" +
 	"\tnum_items\x18\x01 \x01(\x04R\bnumItems\x12\x1b\n" +
 	"\titem_head\x18\x02 \x01(\tR\bitemHead\x12\x1b\n" +
@@ -721,7 +811,7 @@ func file_redis_proto_rawDescGZIP() []byte {
 }
 
 var file_redis_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_redis_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_redis_proto_goTypes = []any{
 	(UserAccessLevel)(0),          // 0: types.UserAccessLevel
 	(*User)(nil),                  // 1: types.User
@@ -730,28 +820,32 @@ var file_redis_proto_goTypes = []any{
 	(*BasicObjectMeta)(nil),       // 4: types.BasicObjectMeta
 	(*SetMeta)(nil),               // 5: types.SetMeta
 	(*SortedSetMeta)(nil),         // 6: types.SortedSetMeta
-	(*ListMeta)(nil),              // 7: types.ListMeta
-	(*ListItemMeta)(nil),          // 8: types.ListItemMeta
-	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
+	(*SortedSetItemMeta)(nil),     // 7: types.SortedSetItemMeta
+	(*ListMeta)(nil),              // 8: types.ListMeta
+	(*ListItemMeta)(nil),          // 9: types.ListItemMeta
+	(*timestamppb.Timestamp)(nil), // 10: google.protobuf.Timestamp
 }
 var file_redis_proto_depIdxs = []int32{
-	9,  // 0: types.User.created:type_name -> google.protobuf.Timestamp
-	9,  // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
+	10, // 0: types.User.created:type_name -> google.protobuf.Timestamp
+	10, // 1: types.User.last_login:type_name -> google.protobuf.Timestamp
 	2,  // 2: types.User.rules:type_name -> types.UserACLRule
 	0,  // 3: types.UserACLRule.level:type_name -> types.UserAccessLevel
-	9,  // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
-	9,  // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
-	9,  // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
+	10, // 4: types.ObjectMeta.created:type_name -> google.protobuf.Timestamp
+	10, // 5: types.ObjectMeta.updated:type_name -> google.protobuf.Timestamp
+	10, // 6: types.ObjectMeta.expires:type_name -> google.protobuf.Timestamp
 	4,  // 7: types.ObjectMeta.basic:type_name -> types.BasicObjectMeta
 	5,  // 8: types.ObjectMeta.set:type_name -> types.SetMeta
-	7,  // 9: types.ObjectMeta.list:type_name -> types.ListMeta
-	8,  // 10: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
-	5,  // 11: types.SortedSetMeta.set:type_name -> types.SetMeta
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	6,  // 9: types.ObjectMeta.sorted_set:type_name -> types.SortedSetMeta
+	7,  // 10: types.ObjectMeta.sorted_set_item:type_name -> types.SortedSetItemMeta
+	8,  // 11: types.ObjectMeta.list:type_name -> types.ListMeta
+	9,  // 12: types.ObjectMeta.list_item:type_name -> types.ListItemMeta
+	5,  // 13: types.SortedSetMeta.set:type_name -> types.SetMeta
+	4,  // 14: types.SortedSetItemMeta.object:type_name -> types.BasicObjectMeta
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_redis_proto_init() }
@@ -762,6 +856,8 @@ func file_redis_proto_init() {
 	file_redis_proto_msgTypes[2].OneofWrappers = []any{
 		(*ObjectMeta_Basic)(nil),
 		(*ObjectMeta_Set)(nil),
+		(*ObjectMeta_SortedSet)(nil),
+		(*ObjectMeta_SortedSetItem)(nil),
 		(*ObjectMeta_List)(nil),
 		(*ObjectMeta_ListItem)(nil),
 	}
@@ -771,7 +867,7 @@ func file_redis_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_redis_proto_rawDesc), len(file_redis_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -48,6 +48,12 @@ message SetMeta {
   uint64 size_bytes = 3;
 }
 
+message SortedSetMeta {
+  SetMeta set = 1;
+  float min = 2;
+  float max = 3;
+}
+
 message ListMeta {
   uint64 num_items = 1;
   string item_head = 2;

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -49,6 +49,16 @@ message SetMeta {
   uint64 size_bytes = 3;
 }
 
+message SetMember {
+  uint64 uid = 1;
+  string member = 2;
+  optional float score = 3;
+}
+
+message SetMembers {
+  repeated SetMember members = 1;
+}
+
 message SortedSetMeta {
   uint64 num_items = 1;
   uint32 num_chunks = 2;
@@ -67,14 +77,4 @@ message ListItemMeta {
   string previous = 3;
   uint32 num_chunks = 4;
   uint64 size_bytes = 5;
-}
-
-message UIDItem {
-  string member = 1;
-  uint64 uid = 2;
-  optional float score = 3;
-}
-
-message UIDItems {
-  repeated UIDItem items = 1;
 }

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -33,9 +33,8 @@ message ObjectMeta {
     BasicObjectMeta basic = 4;
     SetMeta set = 5;
     SortedSetMeta sorted_set = 6;
-    SortedSetItemMeta sorted_set_item = 7;
-    ListMeta list = 8;
-    ListItemMeta list_item = 9;
+    ListMeta list = 7;
+    ListItemMeta list_item = 8;
   }
 }
 
@@ -56,11 +55,6 @@ message SortedSetMeta {
   float max_score = 3;
 }
 
-message SortedSetItemMeta {
-  BasicObjectMeta object = 1;
-  float score = 2;
-}
-
 message ListMeta {
   uint64 num_items = 1;
   string item_head = 2;
@@ -73,4 +67,9 @@ message ListItemMeta {
   string previous = 3;
   uint32 num_chunks = 4;
   uint64 size_bytes = 5;
+}
+
+message UIDItem {
+  string member = 1;
+  optional float score = 2;
 }

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -32,9 +32,8 @@ message ObjectMeta {
   oneof type {
     BasicObjectMeta basic = 4;
     SetMeta set = 5;
-    SortedSetMeta sorted_set = 6;
-    ListMeta list = 7;
-    ListItemMeta list_item = 8;
+    ListMeta list = 6;
+    ListItemMeta list_item = 7;
   }
 }
 
@@ -47,12 +46,6 @@ message SetMeta {
   uint64 num_items = 1;
   uint32 num_chunks = 2;
   uint64 size_bytes = 3;
-}
-
-message SortedSetMeta {
-  SetMeta set = 1;
-  float min_score = 2;
-  float max_score = 3;
 }
 
 message ListMeta {

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -32,8 +32,10 @@ message ObjectMeta {
   oneof type {
     BasicObjectMeta basic = 4;
     SetMeta set = 5;
-    ListMeta list = 6;
-    ListItemMeta list_item = 7;
+    SortedSetMeta sorted_set = 6;
+    SortedSetItemMeta sorted_set_item = 7;
+    ListMeta list = 8;
+    ListItemMeta list_item = 9;
   }
 }
 
@@ -50,8 +52,13 @@ message SetMeta {
 
 message SortedSetMeta {
   SetMeta set = 1;
-  float min = 2;
-  float max = 3;
+  float min_score = 2;
+  float max_score = 3;
+}
+
+message SortedSetItemMeta {
+  BasicObjectMeta object = 1;
+  float score = 2;
 }
 
 message ListMeta {

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -74,3 +74,7 @@ message UIDItem {
   uint64 uid = 2;
   optional float score = 3;
 }
+
+message UIDItems {
+  repeated UIDItem items = 1;
+}

--- a/internal/types/redis.proto
+++ b/internal/types/redis.proto
@@ -32,8 +32,9 @@ message ObjectMeta {
   oneof type {
     BasicObjectMeta basic = 4;
     SetMeta set = 5;
-    ListMeta list = 6;
-    ListItemMeta list_item = 7;
+    SortedSetMeta sorted_set = 6;
+    ListMeta list = 7;
+    ListItemMeta list_item = 8;
   }
 }
 
@@ -43,6 +44,12 @@ message BasicObjectMeta {
 }
 
 message SetMeta {
+  uint64 num_items = 1;
+  uint32 num_chunks = 2;
+  uint64 size_bytes = 3;
+}
+
+message SortedSetMeta {
   uint64 num_items = 1;
   uint32 num_chunks = 2;
   uint64 size_bytes = 3;
@@ -64,5 +71,6 @@ message ListItemMeta {
 
 message UIDItem {
   string member = 1;
-  optional float score = 2;
+  uint64 uid = 2;
+  optional float score = 3;
 }


### PR DESCRIPTION
This brings in just the subset of ordered set commands we need for internal use.

We store a new `zset/<set_id>` directory that contains the list of scores per ordered set, sorted from low to high with a stable, sortable floating point sort score.

Every score bucket can have one or more items, ie:

```
127.0.0.1:6380> zadd z 10 10
(integer) 1
127.0.0.1:6380> zadd z 10 101
(integer) 1
127.0.0.1:6380> zcount z -inf +inf
(integer) 2
```